### PR TITLE
Remove defunct rule reference

### DIFF
--- a/rules/standard/draft-06.json
+++ b/rules/standard/draft-06.json
@@ -11,7 +11,7 @@
             "maxProperties", "required", "dependencies", "propertyNames", "type", "const", "enum",
             "allOf", "anyOf", "oneOf", "not", "format"
         ],
-        "implementation": ["allowBooleanSchema", "allowIntegerWithFractionalPart", "exclusiveMinMaxIsNumber"]
+        "implementation": ["allowBooleanSchema", "allowIntegerWithFractionalPart"]
     },
     "metadata": {
         "validation": {


### PR DESCRIPTION
## What
 * Remove reference to an old type rule for draft-06.

## Why
 * This is now handled by the 'allow-type' info rule.